### PR TITLE
Switch env variables prefix from REACT_APP to GATSBY

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,12 +71,12 @@ Get an overview of Firebase, how to create a project, what kind of features Fire
 The *.env* or *.env.development* and *.env.production* files could look like the following then:
 
 ```
-REACT_APP_API_KEY=AIzaSyBtxZ3phPeXcsZsRTySIXa7n33NtQ
-REACT_APP_AUTH_DOMAIN=react-firebase-s2233d64f8.firebaseapp.com
-REACT_APP_DATABASE_URL=https://react-firebase-s2233d64f8.firebaseio.com
-REACT_APP_PROJECT_ID=react-firebase-s2233d64f8
-REACT_APP_STORAGE_BUCKET=react-firebase-s2233d64f8.appspot.com
-REACT_APP_MESSAGING_SENDER_ID=701928454501
+GATSBY_API_KEY=AIzaSyBtxZ3phPeXcsZsRTySIXa7n33NtQ
+GATSBY_AUTH_DOMAIN=react-firebase-s2233d64f8.firebaseapp.com
+GATSBY_DATABASE_URL=https://react-firebase-s2233d64f8.firebaseio.com
+GATSBY_PROJECT_ID=react-firebase-s2233d64f8
+GATSBY_STORAGE_BUCKET=react-firebase-s2233d64f8.appspot.com
+GATSBY_MESSAGING_SENDER_ID=701928454501
 ```
 
 ### Activate Sign-In Methods
@@ -101,13 +101,13 @@ The *.env* or *.env.development* and *.env.production* files could look like the
 **Development:**
 
 ```
-REACT_APP_CONFIRMATION_EMAIL_REDIRECT=http://localhost:3000
+GATSBY_CONFIRMATION_EMAIL_REDIRECT=http://localhost:3000
 ```
 
 **Production:**
 
 ```
-REACT_APP_CONFIRMATION_EMAIL_REDIRECT=https://mydomain.com
+GATSBY_CONFIRMATION_EMAIL_REDIRECT=https://mydomain.com
 ```
 
 ## Setup via Gatsby CLI

--- a/src/components/Firebase/firebase.js
+++ b/src/components/Firebase/firebase.js
@@ -1,10 +1,10 @@
 const config = {
-  apiKey: process.env.REACT_APP_API_KEY,
-  authDomain: process.env.REACT_APP_AUTH_DOMAIN,
-  databaseURL: process.env.REACT_APP_DATABASE_URL,
-  projectId: process.env.REACT_APP_PROJECT_ID,
-  storageBucket: process.env.REACT_APP_STORAGE_BUCKET,
-  messagingSenderId: process.env.REACT_APP_MESSAGING_SENDER_ID,
+  apiKey: process.env.GATSBY_API_KEY,
+  authDomain: process.env.GATSBY_AUTH_DOMAIN,
+  databaseURL: process.env.GATSBY_DATABASE_URL,
+  projectId: process.env.GATSBY_PROJECT_ID,
+  storageBucket: process.env.GATSBY_STORAGE_BUCKET,
+  messagingSenderId: process.env.GATSBY_MESSAGING_SENDER_ID,
 };
 
 class Firebase {
@@ -51,7 +51,7 @@ class Firebase {
 
   doSendEmailVerification = () =>
     this.auth.currentUser.sendEmailVerification({
-      url: process.env.REACT_APP_CONFIRMATION_EMAIL_REDIRECT,
+      url: process.env.GATSBY_CONFIRMATION_EMAIL_REDIRECT,
     });
 
   doPasswordUpdate = password =>


### PR DESCRIPTION
Hello, 
first of all, thanks for this amazing starter!
I experienced some issues by deploying it via CI/CD tools like CircleCI:

since the environment variables are stored inside the platform, and not in a .env file, Gatsby build process fails.

I solved it by changing the prefix from REACT_APP to GATSBY, as suggested here:

[https://www.gatsbyjs.org/docs/environment-variables/#client-side-javascript](https://www.gatsbyjs.org/docs/environment-variables/#client-side-javascript)

I guess this happens because Firebase is a client-side script.

Let me know what you think!
Cheers, 

Leonardo
