### PR TITLE
Adding gatsby-config.js to root dir

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,0 +1,3 @@
+require("dotenv").config({
+  path: `.env.${process.env.NODE_ENV}`,
+})


### PR DESCRIPTION
As directed by gatsby docs, if using environment variables (env) add the above code in gatsby-config file. This lets the `dotenv`  - an already installed inner dependency of gatsby - to make (env) available instantly