### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,10 +8,11 @@
     "serve": "gatsby serve"
   },
   "dependencies": {
-    "firebase": "^5.6.0",
-    "gatsby": "^2.0.33",
-    "react": "^16.5.1",
-    "react-dom": "^16.5.1",
-    "recompose": "^0.30.0"
+    "firebase": "^6.0.2",
+    "gatsby": "^2.4.3",
+    "react": "^16.8.6",
+    "react-dom": "^16.8.6",
+    "recompose": "^0.30.0",
+    "core-js": "^2.6.5"
   }
 }


### PR DESCRIPTION
As been the recent issue with many users, the project fails with current dependencies. So, I'm updating the already installed dependencies to the latest versions, and adding `cire-js` to 2.6.5 (as it currecntly works well with latest gatsby release) as the project's inner node dependencies demand it