### PR TITLE
Changed env variables prefix to GATSBY

### DIFF
--- a/src/components/Firebase/firebase.js
+++ b/src/components/Firebase/firebase.js
@@ -1,10 +1,10 @@
 const config = {
-  apiKey: process.env.REACT_APP_API_KEY,
-  authDomain: process.env.REACT_APP_AUTH_DOMAIN,
-  databaseURL: process.env.REACT_APP_DATABASE_URL,
-  projectId: process.env.REACT_APP_PROJECT_ID,
-  storageBucket: process.env.REACT_APP_STORAGE_BUCKET,
-  messagingSenderId: process.env.REACT_APP_MESSAGING_SENDER_ID,
+  apiKey: process.env.GATSBY_API_KEY,
+  authDomain: process.env.GATSBY_AUTH_DOMAIN,
+  databaseURL: process.env.GATSBY_DATABASE_URL,
+  projectId: process.env.GATSBY_PROJECT_ID,
+  storageBucket: process.env.GATSBY_STORAGE_BUCKET,
+  messagingSenderId: process.env.GATSBY_MESSAGING_SENDER_ID,
 };
 
 class Firebase {
@@ -51,7 +51,7 @@ class Firebase {
 
   doSendEmailVerification = () =>
     this.auth.currentUser.sendEmailVerification({
-      url: process.env.REACT_APP_CONFIRMATION_EMAIL_REDIRECT,
+      url: process.env.GATSBY_CONFIRMATION_EMAIL_REDIRECT,
     });
 
   doPasswordUpdate = password =>


### PR DESCRIPTION
According to Gatsby, for the env variables to be available in client-side (browser) include 'GATSBY' prefic in the beginning