### PR TITLE
Clarify order of setup instructions to avoid errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,9 +53,11 @@ If you are creating an open source application under a license compatible with t
 
 ## Installation
 
-* `git clone https://github.com:the-road-to-react-with-firebase/react-gatsby-firebase-authentication.git`
+* `git clone https://github.com/the-road-to-react-with-firebase/react-gatsby-firebase-authentication.git`
 * `cd react-gatsby-firebase-authentication`
 * `npm install`
+* save the [Firebase credentials](#firebase-configuration)
+* setup the [security rules](#security-rules)
 * `npm start`
 * visit http://localhost:8000
 
@@ -112,6 +114,8 @@ GATSBY_CONFIRMATION_EMAIL_REDIRECT=https://mydomain.com
 
 ### Security Rules
 
+In the Firebase console, go to Database, select "Realtime Database" -> Rules, and paste the rules below:
+
 ```
 {
   "rules": {
@@ -139,7 +143,7 @@ GATSBY_CONFIRMATION_EMAIL_REDIRECT=https://mydomain.com
 
 ## Setup via Gatsby CLI
 
-* `gatsby new react-gatsby-firebase-authentication https://github.com:the-road-to-react-with-firebase/react-gatsby-firebase-authentication.git`
+* `gatsby new react-gatsby-firebase-authentication https://github.com/the-road-to-react-with-firebase/react-gatsby-firebase-authentication.git`
 * `cd react-gatsby-firebase-authentication`
 * `npm install`
 * `gatsby develop`


### PR DESCRIPTION
I was getting PERMISSION_DENIED and in the console,

> @firebase/database: FIREBASE WARNING: set at /users/4OKJRG0UF9gsZ5VhePffbneu54F2 failed: permission_denied

![image](https://user-images.githubusercontent.com/33569/59142686-60d9fd80-8987-11e9-803f-a2c1e8205a0c.png)

Turns out I hadn't yet pasted the security rules. This PR clarifies when and how to do so.